### PR TITLE
disable caching when installing with pip to save on space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN echo deb http://deb.debian.org/debian buster-backports main contrib > /etc/a
  && DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical apt-get -qqy --no-install-recommends -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-unsafe-io update \
  && DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical apt-get -qqy --no-install-recommends -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-unsafe-io install rsync liblua5.1-0 libluajit-5.1-2 libidn11 lua-socket libpsl5 git \
  && DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical apt-get -qqy --no-install-recommends -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-unsafe-io -t buster-backports install zstd libzstd-dev libzstd1 \
- && pip install requests seesaw warcio zstandard \
+ && pip install --no-cache-dir requests seesaw warcio zstandard \
  && chmod +x /usr/local/bin/wget-lua \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /grab


### PR DESCRIPTION
Saves about 4MB on image size according to a quick check.
Thought it would be useful, since the `apt-get` cache is also removed. 